### PR TITLE
Bug in rsub

### DIFF
--- a/dual/ad_dual.py
+++ b/dual/ad_dual.py
@@ -1,8 +1,8 @@
 ################################################################################
 #                                                                              #
-#	UJJWAL KHANDELWAL                                                       #    
-#	DUAL NUMBERS AND AUTOMATIC DIFFERENTIATION                              #
-#	PYTHON 3.7.10                                                           #
+#	UJJWAL KHANDELWAL                                                      #    
+#	DUAL NUMBERS AND AUTOMATIC DIFFERENTIATION                             #
+#	PYTHON 3.7.10                                                          #
 #                                                                              #
 ################################################################################
 

--- a/dual/ad_dual.py
+++ b/dual/ad_dual.py
@@ -1,8 +1,8 @@
 ################################################################################
 #                                                                              #
-#	UJJWAL KHANDELWAL                                                      #    
-#	DUAL NUMBERS AND AUTOMATIC DIFFERENTIATION                             #
-#	PYTHON 3.7.10                                                          #
+#	UJJWAL KHANDELWAL                                                            #    
+#	DUAL NUMBERS AND AUTOMATIC DIFFERENTIATION                                   #
+#	PYTHON 3.7.10                                                                #
 #                                                                              #
 ################################################################################
 
@@ -55,19 +55,7 @@ class Dual:
             return Dual(self.real - argument, self.dual)
         
     def __rsub__(self, argument):
-        if isinstance(argument, Dual):
-            real = -self.real + argument.real
-            dual = {}
-            for key in argument.dual:
-                dual[key] = argument.dual[key]
-            for key in self.dual:
-                if key in dual:
-                    dual[key] -= self.dual[key]
-                else:
-                    dual[key] = -self.dual[key]    
-            return Dual(real, dual)
-        else:
-            return Dual(-self.real + argument, self.dual)
+            return -self + argument
     
     def __mul__(self, argument):
         if isinstance(argument, Dual):

--- a/dual/ad_dual.py
+++ b/dual/ad_dual.py
@@ -1,8 +1,8 @@
 ################################################################################
 #                                                                              #
-#	UJJWAL KHANDELWAL                                                            #    
-#	DUAL NUMBERS AND AUTOMATIC DIFFERENTIATION                                   #
-#	PYTHON 3.7.10                                                                #
+#	UJJWAL KHANDELWAL                                                       #    
+#	DUAL NUMBERS AND AUTOMATIC DIFFERENTIATION                              #
+#	PYTHON 3.7.10                                                           #
 #                                                                              #
 ################################################################################
 


### PR DESCRIPTION
Thank you for sharing this simple library with the community!

The implementation of the `__rsub__` operator for `Dual` has a problem that produces wrong derivatives in the case that the `argument` is not of type `Dual`. The problem is that, although the `real` part of the number is negated, the `dual` part is not updated accordingly. This merge request fixes this issue.

Minimal code to reproduce:

```python
from ad_dual import Dual
x = Dual(0.25, {"x": 1.0})
y = (1 - x)
print(y)
```

Produces: 
```
f = 0.75
fx = 1.0 # the derivative of 1 - x should be -1!
```

